### PR TITLE
Support locking individual slots

### DIFF
--- a/lib/atecc508a/request.ex
+++ b/lib/atecc508a/request.ex
@@ -128,6 +128,23 @@ defmodule ATECC508A.Request do
   end
 
   @doc """
+  Lock a specific slot.
+  """
+  @spec lock_slot(Transport.t(), slot()) :: :ok | {:error, atom()}
+  def lock_slot(transport, slot) do
+    # Need to calculate the CRC of everything written in the zone to be
+    # locked for this to work.
+
+    # See Table 9-31 - Mode Encoding
+    mode = <<0::size(2), slot::size(4), 2::size(2)>>
+    payload = <<@atecc508a_op_lock, mode::binary, 0::size(16)>>
+
+    Transport.request(transport, payload, 35, 1)
+    |> interpret_result()
+    |> return_status()
+  end
+
+  @doc """
   Request a random number.
   """
   @spec random(Transport.t()) :: {:ok, binary()} | {:error, atom()}

--- a/test/atecc508a/request_test.exs
+++ b/test/atecc508a/request_test.exs
@@ -121,6 +121,17 @@ defmodule ATECC508A.RequestTest do
     assert Request.lock_zone(@mock_transport, :data, <<0xAA, 0x55>>) == :ok
   end
 
+  test "lock slots" do
+    ATECC508A.Transport.Mock
+    |> expect(:request, fn _, <<0x17, 0x02, 0, 0>>, 35, 1 -> {:ok, <<0>>} end)
+    |> expect(:request, fn _, <<0x17, 0x06, 0, 0>>, 35, 1 -> {:ok, <<0>>} end)
+    |> expect(:request, fn _, <<0x17, 0x3E, 0, 0>>, 35, 1 -> {:ok, <<0>>} end)
+
+    assert Request.lock_slot(@mock_transport, 0) == :ok
+    assert Request.lock_slot(@mock_transport, 1) == :ok
+    assert Request.lock_slot(@mock_transport, 15) == :ok
+  end
+
   test "genkey slot 0" do
     ATECC508A.Transport.Mock
     |> expect(:request, fn _, <<0x40, 4, 0, 0>>, 653, 64 -> {:ok, @test_data_64} end)


### PR DESCRIPTION
This is required to lock down the private key. It's possible to
regenerate the private key even with a locked data section and the
read-only bit set in the slot config.