### PR TITLE
Reduce device cert validity to 30 years

### DIFF
--- a/lib/atecc508a/certificate.ex
+++ b/lib/atecc508a/certificate.ex
@@ -12,7 +12,7 @@ defmodule ATECC508A.Certificate do
 
   @hash :sha256
   @curve :secp256r1
-  @validity_years 31
+  @validity_years 30
   @version :v3
   @era 2000
 

--- a/test/atecc508a/certificate_test.exs
+++ b/test/atecc508a/certificate_test.exs
@@ -38,7 +38,7 @@ defmodule ATECC508A.CertificateTest do
     manufacturing_sn = "1234"
 
     ecc508a_validity =
-      ATECC508A.Validity.create_compatible_validity(31)
+      ATECC508A.Validity.create_compatible_validity(30)
       |> ATECC508A.Validity.compress()
 
     cert_sn = ATECC508A.SerialNumber.from_device_sn(ecc508a_sn, ecc508a_validity)


### PR DESCRIPTION
This avoids the UTC vs. Generic time issue at 2050 until there's time to
look into it and test out the fix.