### PR TITLE
Add detected?/1 to Transport

### DIFF
--- a/lib/atecc508a/transport.ex
+++ b/lib/atecc508a/transport.ex
@@ -14,9 +14,16 @@ defmodule ATECC508A.Transport do
               response_payload_len :: non_neg_integer()
             ) :: {:ok, binary()} | {:error, atom()}
 
+  @callback detected?(arg :: any) :: boolean()
+
   @spec request(t(), binary(), non_neg_integer(), non_neg_integer()) ::
           {:ok, binary()} | {:error, atom()}
   def request({mod, arg}, payload, timeout, response_payload_len) do
     mod.request(arg, payload, timeout, response_payload_len)
+  end
+
+  @spec detected?(t()) :: boolean()
+  def detected?({mod, arg}) do
+    mod.detected?(arg)
   end
 end

--- a/lib/atecc508a/transport/i2c.ex
+++ b/lib/atecc508a/transport/i2c.ex
@@ -61,6 +61,22 @@ defmodule ATECC508A.Transport.I2C do
   end
 
   @doc """
+  Detects if an ATECC508A is available at the address
+  """
+  @impl Transport
+  @spec detected?(instance()) :: boolean()
+  def detected?({i2c, address}) do
+    case wakeup(i2c, address) do
+      :ok ->
+        sleep(i2c, address)
+        true
+
+      _ ->
+        false
+    end
+  end
+
+  @doc """
   Package up a request for transmission over I2C
   """
   @spec package(binary()) :: iodata()


### PR DESCRIPTION
This exposes a way to detect if an ATECC508/608A is available on the specified transport