### PR TITLE
Improve performance by polling the ATECC508A and caching results

### DIFF
--- a/lib/atecc508a/transport/cache.ex
+++ b/lib/atecc508a/transport/cache.ex
@@ -1,0 +1,51 @@
+defmodule ATECC508A.Transport.Cache do
+  @moduledoc """
+  Simple cache for reducing unnecessary traffic to the ATECC508A
+  """
+
+  @type state() :: map()
+
+  @atecc508a_op_read 0x02
+  @atecc508a_op_genkey 0x40
+  @atecc508a_op_random 0x1B
+
+  @doc """
+  Initialize the cache for one ATECC508A
+  """
+  @spec init() :: state()
+  def init() do
+    %{}
+  end
+
+  @doc """
+  Check if the specified request is in the cache
+  """
+  @spec get(state(), binary()) :: binary() | nil
+  def get(cache, request) do
+    Map.get(cache, request)
+  end
+
+  @doc """
+  Save a response back to the cache
+  """
+  @spec put(state, binary(), any()) :: state()
+
+  # Cache all reads
+  def put(cache, <<@atecc508a_op_read, _::binary>> = request, response) do
+    Map.put(cache, request, response)
+  end
+
+  # Cache the response to getting a public key
+  def put(cache, <<@atecc508a_op_genkey, 0, _key_id::little-16>> = request, response) do
+    Map.put(cache, request, response)
+  end
+
+  # Don't cache random numbers
+  def put(cache, <<@atecc508a_op_random, _::binary>>, _response), do: cache
+
+  # Flush the cache on everything else:
+  #   writes, locks, etc.
+  #
+  # This is overkill, but safe.
+  def put(_cache, _request, _response), do: %{}
+end

--- a/test/atecc508a/transport/cache_test.exs
+++ b/test/atecc508a/transport/cache_test.exs
@@ -1,0 +1,53 @@
+defmodule ATECC508A.Transport.CacheTest do
+  use ExUnit.Case
+
+  alias ATECC508A.Transport.Cache
+
+  test "caches reads" do
+    req = <<2, 0, 0, 0>>
+    resp = {:ok, <<1>>}
+
+    cache = Cache.init()
+    assert Cache.get(cache, req) == nil
+
+    cache = Cache.put(cache, req, resp)
+    assert Cache.get(cache, req) == resp
+  end
+
+  test "cache genkey public key calculation " do
+    req = <<0x40, 0, 1, 0>>
+    resp = {:ok, <<1, 2, 3, 4, 5>>}
+
+    cache = Cache.init()
+    assert Cache.get(cache, req) == nil
+
+    cache = Cache.put(cache, req, resp)
+    assert Cache.get(cache, req) == resp
+  end
+
+  test "doesn't cache genkey creation" do
+    req = <<0x40, 1, 1, 0>>
+    resp = {:ok, <<1, 2, 3, 4, 5>>}
+
+    cache = Cache.init()
+    assert Cache.get(cache, req) == nil
+
+    cache = Cache.put(cache, req, resp)
+    assert Cache.get(cache, req) == nil
+  end
+
+  test "writes clear the cache" do
+    read_req = <<2, 0, 0, 0>>
+    write_req = <<0x12, 0, 0, 0>>
+    resp = {:ok, <<1>>}
+
+    cache = Cache.init()
+    assert Cache.get(cache, read_req) == nil
+
+    cache = Cache.put(cache, read_req, resp)
+    assert Cache.get(cache, read_req) == resp
+
+    cache = Cache.put(cache, write_req, resp)
+    assert cache == %{}
+  end
+end

--- a/test/atecc508a/transport/i2c_test.exs
+++ b/test/atecc508a/transport/i2c_test.exs
@@ -1,4 +1,4 @@
-defmodule ATECC508A.I2CTransportTest do
+defmodule ATECC508A.Transport.I2CTest do
   use ExUnit.Case
 
   alias ATECC508A.Transport.I2CServer


### PR DESCRIPTION
This adds two features to the library. The first is that it polls the ATECC508A for earlier completion of commands. The timings that are hardcoded in the library are worst case, so this improves performance. The second change is to cache reads. The cache is very simplistic and gets completely invalidated with a write, lock, or pretty much anything. This matches the current use cases where it's either provision time where very little needs to be cached since it's mostly writes and the normal runtime case where there are a bunch of reads and then the library is mostly idle.

Both of these changes reduce the contention between nerves_key_pkcs11 and this library when using both nerves_hub and AWS IoT. Contention is still possible and will likely need to be address in the future when there's more use after initialization.