### PR TITLE
Add info method to transport

### DIFF
--- a/lib/atecc508a/transport.ex
+++ b/lib/atecc508a/transport.ex
@@ -16,6 +16,8 @@ defmodule ATECC508A.Transport do
 
   @callback detected?(arg :: any) :: boolean()
 
+  @callback info(id :: any()) :: map()
+
   @doc """
   Send a request to the ATECC508A and wait for a response
 
@@ -39,5 +41,15 @@ defmodule ATECC508A.Transport do
   @spec detected?(t()) :: boolean()
   def detected?({mod, arg}) do
     mod.detected?(arg)
+  end
+
+  @doc """
+  Return information about this transport
+
+  This information is specific to this transport. No fields are required.
+  """
+  @spec info(t()) :: map()
+  def info({mod, arg}) do
+    mod.info(arg)
   end
 end

--- a/lib/atecc508a/transport/i2c.ex
+++ b/lib/atecc508a/transport/i2c.ex
@@ -62,6 +62,10 @@ defmodule ATECC508A.Transport.I2C do
   defdelegate request(instance, payload, timeout, response_payload_len),
     to: ATECC508A.Transport.I2CServer
 
+  @impl Transport
+  @spec info(instance()) :: map()
+  defdelegate info(instance), to: ATECC508A.Transport.I2CServer
+
   defp process_name(bus_name, address) do
     Module.concat([ATECC508A.Transport.I2C, bus_name, to_string(address)])
   end

--- a/lib/atecc508a/transport/i2c_server.ex
+++ b/lib/atecc508a/transport/i2c_server.ex
@@ -33,11 +33,19 @@ defmodule ATECC508A.Transport.I2CServer do
     GenServer.call(server, {:request, payload, timeout, response_payload_len})
   end
 
+  @doc """
+  Returns information about the transport
+  """
+  @spec info(GenServer.server()) :: map()
+  def info(server) do
+    GenServer.call(server, :info)
+  end
+
   @impl true
   def init([bus_name, address]) do
     {:ok, i2c} = Circuits.I2C.open(bus_name)
 
-    state = %{i2c: i2c, address: address, cache: Cache.init()}
+    state = %{i2c: i2c, bus_name: bus_name, address: address, cache: Cache.init()}
     {:ok, state, {:continue, :start_asleep}}
   end
 
@@ -80,6 +88,12 @@ defmodule ATECC508A.Transport.I2CServer do
       response ->
         {:reply, response, state}
     end
+  end
+
+  @impl true
+  def handle_call(:info, _from, state) do
+    info = %{type: ATECC508A.Transport.I2C, bus_name: state.bus_name, address: state.address}
+    {:reply, info, state}
   end
 
   @doc """


### PR DESCRIPTION
This is useful for getting information about a transport when you're
just passed a reference to it.