### PR TITLE
Add sign digest request

### DIFF
--- a/lib/atecc508a/transport/cache.ex
+++ b/lib/atecc508a/transport/cache.ex
@@ -3,49 +3,72 @@ defmodule ATECC508A.Transport.Cache do
   Simple cache for reducing unnecessary traffic to the ATECC508A
   """
 
-  @type state() :: map()
+  use GenServer
 
   @atecc508a_op_read 0x02
   @atecc508a_op_genkey 0x40
   @atecc508a_op_random 0x1B
 
-  @doc """
-  Initialize the cache for one ATECC508A
-  """
-  @spec init() :: state()
-  def init() do
-    %{}
+  @spec start_link() :: GenServer.on_start()
+  def start_link do
+    GenServer.start_link(__MODULE__, nil)
   end
 
   @doc """
   Check if the specified request is in the cache
   """
-  @spec get(state(), binary()) :: binary() | nil
-  def get(cache, request) do
-    Map.get(cache, request)
+  @spec get(GenServer.server(), binary()) :: binary() | nil
+  def get(pid, request) do
+    GenServer.call(pid, {:get, request})
   end
 
   @doc """
   Save a response back to the cache
   """
-  @spec put(state, binary(), any()) :: state()
+  @spec put(GenServer.server(), binary(), any()) :: any()
 
   # Cache all reads
-  def put(cache, <<@atecc508a_op_read, _::binary>> = request, response) do
-    Map.put(cache, request, response)
+  def put(pid, <<@atecc508a_op_read, _::binary>> = request, response) do
+    GenServer.call(pid, {:put, request, response})
   end
 
   # Cache the response to getting a public key
-  def put(cache, <<@atecc508a_op_genkey, 0, _key_id::little-16>> = request, response) do
-    Map.put(cache, request, response)
+  def put(pid, <<@atecc508a_op_genkey, 0, _key_id::little-16>> = request, response) do
+    GenServer.call(pid, {:put, request, response})
   end
 
   # Don't cache random numbers
-  def put(cache, <<@atecc508a_op_random, _::binary>>, _response), do: cache
+  def put(_pid, <<@atecc508a_op_random, _::binary>>, response), do: response
 
   # Flush the cache on everything else:
   #   writes, locks, etc.
   #
   # This is overkill, but safe.
-  def put(_cache, _request, _response), do: %{}
+  def put(pid, _request, response) do
+    GenServer.call(pid, :flush)
+    response
+  end
+
+  @impl true
+  def init(_) do
+    cache = %{}
+    {:ok, cache}
+  end
+
+  @impl true
+  def handle_call({:get, request}, _from, cache) do
+    result = Map.get(cache, request)
+    {:reply, result, cache}
+  end
+
+  @impl true
+  def handle_call({:put, request, response}, _from, cache) do
+    new_cache = Map.put(cache, request, response)
+    {:reply, response, new_cache}
+  end
+
+  @impl true
+  def handle_call(:flush, _from, _cache) do
+    {:reply, :ok, %{}}
+  end
 end

--- a/lib/atecc508a/transport/i2c.ex
+++ b/lib/atecc508a/transport/i2c.ex
@@ -63,6 +63,11 @@ defmodule ATECC508A.Transport.I2C do
     to: ATECC508A.Transport.I2CServer
 
   @impl Transport
+  @spec transaction(instance(), (fun() -> {:ok, any()} | {:error, atom()})) ::
+          {:ok, any()} | {:error, atom()}
+  defdelegate transaction(instance, callback), to: ATECC508A.Transport.I2CServer
+
+  @impl Transport
   @spec info(instance()) :: map()
   defdelegate info(instance), to: ATECC508A.Transport.I2CServer
 

--- a/lib/atecc508a/transport/i2c_server.ex
+++ b/lib/atecc508a/transport/i2c_server.ex
@@ -36,6 +36,15 @@ defmodule ATECC508A.Transport.I2CServer do
   end
 
   @doc """
+  Run the callback function inside a transaction that doesn't sleep
+  """
+  @spec transaction(GenServer.server(), (fun() -> {:ok, any()} | {:error, atom()})) ::
+          {:ok, any()} | {:error, atom()}
+  def transaction(server, callback) do
+    GenServer.call(server, {:transaction, callback})
+  end
+
+  @doc """
   Returns information about the transport
   """
   @spec info(GenServer.server()) :: map()
@@ -45,9 +54,10 @@ defmodule ATECC508A.Transport.I2CServer do
 
   @impl true
   def init([bus_name, address]) do
+    {:ok, cache} = Cache.start_link()
     {:ok, i2c} = Circuits.I2C.open(bus_name)
 
-    state = %{i2c: i2c, bus_name: bus_name, address: address, cache: Cache.init()}
+    state = %{i2c: i2c, bus_name: bus_name, address: address, cache: cache}
     {:ok, state, {:continue, :start_asleep}}
   end
 
@@ -76,20 +86,18 @@ defmodule ATECC508A.Transport.I2CServer do
 
   @impl true
   def handle_call({:request, payload, timeout, response_payload_len}, _from, state) do
-    case Cache.get(state.cache, payload) do
-      nil ->
-        case make_request(state, payload, timeout, response_payload_len) do
-          {:ok, _message} = rc ->
-            new_cache = Cache.put(state.cache, payload, rc)
-            {:reply, rc, %{state | cache: new_cache}}
+    response =
+      do_transaction(state.i2c, state.address, state.cache, fn request ->
+        request.(payload, timeout, response_payload_len)
+      end)
 
-          error ->
-            {:reply, error, state}
-        end
+    {:reply, response, state}
+  end
 
-      response ->
-        {:reply, response, state}
-    end
+  @impl true
+  def handle_call({:transaction, callback}, _from, state) do
+    response = do_transaction(state.i2c, state.address, state.cache, callback)
+    {:reply, response, state}
   end
 
   @impl true
@@ -122,18 +130,59 @@ defmodule ATECC508A.Transport.I2CServer do
     end
   end
 
-  defp make_request(state, payload, timeout, response_payload_len) do
+  defp do_transaction(i2c, address, cache, callback) do
+    rc =
+      case wakeup(i2c, address) do
+        :ok ->
+          request_fn = fn payload, timeout, response_payload_len ->
+            make_cached_request(payload, timeout, response_payload_len, i2c, address, cache)
+          end
+
+          case callback.(request_fn) do
+            {:ok, _data} = response -> response
+            {:error, _reason} = error -> error
+          end
+
+        error ->
+          _ = Logger.error("ATECC508A: Transaction failed: #{inspect(error)}")
+          error
+      end
+
+    # Always send a sleep after a request even if it fails so that the processor is in
+    # a known state for the next call.
+    _ = sleep(i2c, address)
+
+    rc
+  end
+
+  defp make_cached_request(payload, timeout, response_payload_len, i2c, address, cache) do
+    case Cache.get(cache, payload) do
+      nil ->
+        case make_request(payload, timeout, response_payload_len, i2c, address) do
+          {:ok, _message} = rc ->
+            Cache.put(cache, payload, rc)
+            rc
+
+          error ->
+            error
+        end
+
+      response ->
+        response
+    end
+  end
+
+  defp make_request(payload, timeout, response_payload_len, i2c, address) do
     to_send = package(payload)
     response_len = response_payload_len + 3
 
     min_timeout = round(timeout / 2)
 
     rc =
-      with :ok <- wakeup(state.i2c, state.address),
-           :ok <- Circuits.I2C.write(state.i2c, state.address, to_send),
+      with :ok <- Circuits.I2C.write(i2c, address, to_send),
            Process.sleep(min_timeout),
            {:ok, response} <-
-             poll_read(state.i2c, state.address, response_len, min_timeout, timeout) do
+             poll_read(i2c, address, response_len, min_timeout, timeout) do
         unpackage(response)
       else
         error ->
@@ -146,10 +195,6 @@ defmodule ATECC508A.Transport.I2CServer do
 
           error
       end
-
-    # Always send a sleep after a request even if it fails so that the processor is in
-    # a known state for the next call.
-    _ = sleep(state.i2c, state.address)
 
     rc
   end

--- a/test/atecc508a/request_test.exs
+++ b/test/atecc508a/request_test.exs
@@ -152,4 +152,23 @@ defmodule ATECC508A.RequestTest do
 
     assert Request.genkey(@mock_transport, 5, true) == {:ok, @test_data_64}
   end
+
+  test "sign digest slot 0" do
+    ATECC508A.Transport.Mock
+    |> expect(:transaction, fn _, callback ->
+      callback.(fn payload, timeout, response_payload_len ->
+        ATECC508A.Transport.request(@mock_transport, payload, timeout, response_payload_len)
+      end)
+    end)
+
+    ATECC508A.Transport.Mock
+    |> expect(:request, fn _, <<0x16, 0x43, 0, 0, @test_data_32::binary>>, 29, 1 ->
+      {:ok, <<0>>}
+    end)
+
+    ATECC508A.Transport.Mock
+    |> expect(:request, fn _, <<0x41, 0xA0, 0, 0>>, 115, 64 -> {:ok, @test_data_64} end)
+
+    assert Request.sign_digest(@mock_transport, 0, @test_data_32) == {:ok, @test_data_64}
+  end
 end

--- a/test/atecc508a/transport/cache_test.exs
+++ b/test/atecc508a/transport/cache_test.exs
@@ -7,21 +7,21 @@ defmodule ATECC508A.Transport.CacheTest do
     req = <<2, 0, 0, 0>>
     resp = {:ok, <<1>>}
 
-    cache = Cache.init()
+    {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, req) == nil
 
-    cache = Cache.put(cache, req, resp)
+    Cache.put(cache, req, resp)
     assert Cache.get(cache, req) == resp
   end
 
-  test "cache genkey public key calculation " do
+  test "cache genkey public key calculation" do
     req = <<0x40, 0, 1, 0>>
     resp = {:ok, <<1, 2, 3, 4, 5>>}
 
-    cache = Cache.init()
+    {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, req) == nil
 
-    cache = Cache.put(cache, req, resp)
+    Cache.put(cache, req, resp)
     assert Cache.get(cache, req) == resp
   end
 
@@ -29,10 +29,10 @@ defmodule ATECC508A.Transport.CacheTest do
     req = <<0x40, 1, 1, 0>>
     resp = {:ok, <<1, 2, 3, 4, 5>>}
 
-    cache = Cache.init()
+    {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, req) == nil
 
-    cache = Cache.put(cache, req, resp)
+    Cache.put(cache, req, resp)
     assert Cache.get(cache, req) == nil
   end
 
@@ -41,13 +41,13 @@ defmodule ATECC508A.Transport.CacheTest do
     write_req = <<0x12, 0, 0, 0>>
     resp = {:ok, <<1>>}
 
-    cache = Cache.init()
+    {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, read_req) == nil
 
-    cache = Cache.put(cache, read_req, resp)
+    Cache.put(cache, read_req, resp)
     assert Cache.get(cache, read_req) == resp
 
-    cache = Cache.put(cache, write_req, resp)
-    assert cache == %{}
+    Cache.put(cache, write_req, resp)
+    assert Cache.get(cache, write_req) == nil
   end
 end


### PR DESCRIPTION
The goal of this PR is to enable the ATECC to authenticate with Google Cloud Platform's IoT Core MQTT broker. The GCP authentication process involves a [JWT signature](https://cloud.google.com/iot/docs/how-tos/credentials/jwts#jwt_signature) that needs to be handled by the ATECC. This PR adds `Request.sign_digest` to support this use case.

The issue with the library's existing implementation is that the ATECC sleeps between requests, clearing the SRAM between requests. To perform the JWT signature the SHA256 digest needs to be loaded into SRAM with the `nonce` command, and then that digest needs to be signed with the `sign` command. If the ATECC sleeps after the `nonce` command, there is no valid data for the `sign` command and it fails with an execution error.

A path that seemed to have a low impact to the existing codebase and backwards compatibility was to add `Transport.transaction` in order to control the sleep cycle. This allows the ATECC to wake at the beginning of the transaction, perform the necessary requests inside of the callback function, and then sleep when the transaction is complete. Due to GenServer's actor model and the transport's named process, a transaction will "lock" access to the ATECC until its requests are completed, which should prevent conflicts between multiple processes that need to use the ATECC (i.e. NervesHub and MQTT). *I realize `transaction` may be an existing term in the codebase and I'm ok with renaming it if there is a better suggestion.*

As part of this change the `Cache` module needed to be updated to hold its own state. Since a transaction needs to happen in a single message cycle of the transport to guarantee it "locks" the ATECC during this time, it became difficult to maintain the cache during a transaction in this GenServer loop. Therefore the cache is now started as a subprocess of the transport (i.e. each transport still maintains its own cache), and the cache maintains its own state. `Cache` seemed like an internal module, so hopefully this is an acceptable change and doesn't break consumers of the library.

These changes are the foundation of the top-level function `Request.sign_digest`, which is the public interface for this use case. Although `nonce` and `sign` are two separate ATECC commands, I opted to expose the functionality as a single function because they can't work standalone without an overhaul of the sleep/wake cycle. I left transactions as a `Transport` level concept to try to reduce the impact in the codebase; it could be brought up to the `Request` level if nonce and sign need to be discrete commands with a public interface.