### PR TITLE
Support OTP 25

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ install_system_deps: &install_system_deps
         apk add build-base linux-headers
 
 jobs:
-  build_elixir_1_13_otp_24:
+  build_elixir_1_13_otp_25:
     docker:
-      - image: hexpm/elixir:1.13.1-erlang-24.2-alpine-3.15.0
+      - image: hexpm/elixir:1.13.4-erlang-25.0-alpine-3.15.4
     <<: *defaults
     steps:
       - checkout
@@ -43,9 +43,20 @@ jobs:
             - _build
             - deps
 
+  build_elixir_1_13_otp_24:
+    docker:
+      - image: hexpm/elixir:1.13.4-erlang-24.3.4-alpine-3.15.3
+    <<: *defaults
+    steps:
+      - checkout
+      - <<: *install_hex_rebar
+      - <<: *install_system_deps
+      - run: mix deps.get
+      - run: mix test
+
   build_elixir_1_12_otp_24:
     docker:
-      - image: hexpm/elixir:1.12.3-erlang-24.1.2-alpine-3.14.2
+      - image: hexpm/elixir:1.12.3-erlang-24.3.4-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -56,7 +67,7 @@ jobs:
 
   build_elixir_1_11_otp_23:
     docker:
-      - image: hexpm/elixir:1.11.4-erlang-23.3.4-alpine-3.13.3
+      - image: hexpm/elixir:1.11.4-erlang-24.3.4-alpine-3.15.3
     <<: *defaults
     steps:
       - checkout
@@ -113,6 +124,7 @@ workflows:
   version: 2
   build_test:
     jobs:
+      - build_elixir_1_13_otp_25
       - build_elixir_1_13_otp_24
       - build_elixir_1_12_otp_24
       - build_elixir_1_11_otp_23

--- a/.dialyzer_ignore.exs
+++ b/.dialyzer_ignore.exs
@@ -1,5 +1,10 @@
 # Run `mix dialyzer --format short` for strings
 [
+  {"lib/x509/certificate.ex:20:unknown_type Unknown type: X509.ASN1.record/1."},
+  {"lib/x509/certificate/extension.ex:10:unknown_type Unknown type: X509.ASN1.record/1."},
+  {"lib/x509/certificate/validity.ex:15:unknown_type Unknown type: X509.ASN1.record/1."},
+  {"lib/x509/public_key.ex:9:unknown_type Unknown type: :public_key.ec_public_key/0."},
+  {"lib/x509/public_key.ex:9:unknown_type Unknown type: :public_key.rsa_public_key/0."},
   {"lib/atecc508a/certificate.ex:9:unknown_type Unknown type: :public_key.ec_public_key/0."},
   {"lib/atecc508a/certificate.ex:9:unknown_type Unknown type: :public_key.rsa_public_key/0."},
   {"lib/atecc508a/certificate.ex:10:unknown_type Unknown type: X509.ASN1.record/1."},

--- a/lib/atecc508a/request.ex
+++ b/lib/atecc508a/request.ex
@@ -41,7 +41,9 @@ defmodule ATECC508A.Request do
 
   @spec to_config_addr(block(), offset()) :: addr()
   def to_config_addr(block, offset)
-      when block >= 0 and block < 4 and offset >= 0 and offset < 8 do
+      when is_integer(block) and is_integer(offset) and
+             block >= 0 and block < 4 and
+             offset >= 0 and offset < 8 do
     block * 8 + offset
   end
 
@@ -49,7 +51,8 @@ defmodule ATECC508A.Request do
   def to_otp_addr(byte_offset), do: to_config_addr(byte_offset)
 
   @spec to_otp_addr(block(), offset()) :: addr()
-  def to_otp_addr(block, offset), do: to_config_addr(block, offset)
+  def to_otp_addr(block, offset) when is_integer(block) and is_integer(offset),
+    do: to_config_addr(block, offset)
 
   @spec to_data_addr(slot(), 0..416) :: addr()
   def to_data_addr(slot, byte_offset)
@@ -63,7 +66,10 @@ defmodule ATECC508A.Request do
 
   @spec to_data_addr(slot(), block(), offset()) :: addr()
   def to_data_addr(slot, block, offset)
-      when slot >= 0 and slot < 16 and block >= 0 and block < 13 and offset >= 0 and offset < 8 do
+      when is_integer(slot) and is_integer(block) and is_integer(offset) and
+             slot >= 0 and slot < 16 and
+             block >= 0 and block < 13 and
+             offset >= 0 and offset < 8 do
     block * 256 + slot * 8 + offset
   end
 

--- a/lib/atecc508a/transport/i2c.ex
+++ b/lib/atecc508a/transport/i2c.ex
@@ -44,11 +44,17 @@ defmodule ATECC508A.Transport.I2C do
       {:ok, _pid} ->
         {:ok, {__MODULE__, name}}
 
+      {:ok, _pid, _info} ->
+        {:ok, {__MODULE__, name}}
+
       {:error, {:already_started, _pid}} ->
         {:ok, {__MODULE__, name}}
 
+      {:error, _} = err ->
+        err
+
       other_error ->
-        other_error
+        {:error, other_error}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule ATECC508A.MixProject do
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: [
-        flags: [:unmatched_returns, :error_handling, :race_conditions],
+        flags: [:unmatched_returns, :error_handling, :missing_return, :extra_return],
         ignore_warnings: ".dialyzer_ignore.exs"
       ],
       docs: docs(),


### PR DESCRIPTION
* remove deprecated `:race_conditions` dialyzer option
* Add new `:missing_return` and `:extra_return` dialyzer options
* Update Elixir/Erlang CI versions