### PR TITLE
Add retry mechanism that handles the watchdog_about_to_expire error

### DIFF
--- a/test/atecc508a/request_test.exs
+++ b/test/atecc508a/request_test.exs
@@ -171,4 +171,19 @@ defmodule ATECC508A.RequestTest do
 
     assert Request.sign_digest(@mock_transport, 0, @test_data_32) == {:ok, @test_data_64}
   end
+
+  test "watchdog retry mechanism" do
+    ATECC508A.Transport.Mock
+    |> expect(:request, fn _, <<2, 128, 0, 0>>, 5, 32 ->
+      # watchdog about to expire
+      {:ok, <<0xEE>>}
+    end)
+
+    ATECC508A.Transport.Mock
+    |> expect(:request, fn _, <<2, 128, 0, 0>>, 5, 32 ->
+      {:ok, @test_data_32}
+    end)
+
+    assert Request.read_zone(@mock_transport, :config, 0, 32) == {:ok, @test_data_32}
+  end
 end


### PR DESCRIPTION
This adds a retry mechanism that will try for up to one second by default to retry any transaction that return `{:error, :watchdog_about_to_expire}`