### PR TITLE
Only cache successful responses

### DIFF
--- a/lib/atecc508a/transport/i2c_server.ex
+++ b/lib/atecc508a/transport/i2c_server.ex
@@ -119,7 +119,7 @@ defmodule ATECC508A.Transport.I2CServer do
   @doc """
   Extract the response from the data returned from an I2C read
   """
-  @spec unpackage(nonempty_binary()) :: {:ok, binary()} | {:error, :bad_crc | :short_packet}
+  @spec unpackage(binary()) :: {:ok, binary()} | {:error, :bad_crc | :short_packet}
   def unpackage(<<length, payload_and_crc::binary>>) do
     with {:ok, payload, crc} <- extract_payload(length - 3, payload_and_crc),
          ^crc <- ATECC508A.CRC.crc(<<length, payload::binary>>) do

--- a/lib/atecc508a/transport/i2c_server.ex
+++ b/lib/atecc508a/transport/i2c_server.ex
@@ -158,14 +158,9 @@ defmodule ATECC508A.Transport.I2CServer do
   defp make_cached_request(payload, timeout, response_payload_len, i2c, address, cache) do
     case Cache.get(cache, payload) do
       nil ->
-        case make_request(payload, timeout, response_payload_len, i2c, address) do
-          {:ok, _message} = rc ->
-            Cache.put(cache, payload, rc)
-            rc
-
-          error ->
-            error
-        end
+        result = make_request(payload, timeout, response_payload_len, i2c, address)
+        Cache.put(cache, payload, result)
+        result
 
       response ->
         response

--- a/test/atecc508a/transport/cache_test.exs
+++ b/test/atecc508a/transport/cache_test.exs
@@ -5,7 +5,7 @@ defmodule ATECC508A.Transport.CacheTest do
 
   test "caches reads" do
     req = <<2, 0, 0, 0>>
-    resp = {:ok, <<1>>}
+    resp = {:ok, <<1, 2, 3, 4>>}
 
     {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, req) == nil
@@ -14,9 +14,25 @@ defmodule ATECC508A.Transport.CacheTest do
     assert Cache.get(cache, req) == resp
   end
 
+  test "doesn't cache failed reads" do
+    req = <<2, 0, 0, 0>>
+    resp = {:ok, <<1>>}
+
+    {:ok, cache} = Cache.start_link()
+    assert Cache.get(cache, req) == nil
+
+    Cache.put(cache, req, resp)
+    assert Cache.get(cache, req) == nil
+  end
+
   test "cache genkey public key calculation" do
     req = <<0x40, 0, 1, 0>>
-    resp = {:ok, <<1, 2, 3, 4, 5>>}
+
+    resp =
+      {:ok,
+       <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+         25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+         47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64>>}
 
     {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, req) == nil
@@ -27,7 +43,23 @@ defmodule ATECC508A.Transport.CacheTest do
 
   test "doesn't cache genkey creation" do
     req = <<0x40, 1, 1, 0>>
-    resp = {:ok, <<1, 2, 3, 4, 5>>}
+
+    resp =
+      {:ok,
+       <<1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+         25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+         47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64>>}
+
+    {:ok, cache} = Cache.start_link()
+    assert Cache.get(cache, req) == nil
+
+    Cache.put(cache, req, resp)
+    assert Cache.get(cache, req) == nil
+  end
+
+  test "doesn't cache genkey failures" do
+    req = <<0x40, 0, 1, 0>>
+    resp = {:ok, <<1>>}
 
     {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, req) == nil
@@ -38,16 +70,18 @@ defmodule ATECC508A.Transport.CacheTest do
 
   test "writes clear the cache" do
     read_req = <<2, 0, 0, 0>>
+    read_resp = {:ok, <<1, 2, 3, 4>>}
     write_req = <<0x12, 0, 0, 0>>
-    resp = {:ok, <<1>>}
+    write_resp = {:ok, <<0>>}
 
     {:ok, cache} = Cache.start_link()
     assert Cache.get(cache, read_req) == nil
 
-    Cache.put(cache, read_req, resp)
-    assert Cache.get(cache, read_req) == resp
+    Cache.put(cache, read_req, read_resp)
+    assert Cache.get(cache, read_req) == read_resp
 
-    Cache.put(cache, write_req, resp)
+    Cache.put(cache, write_req, write_resp)
     assert Cache.get(cache, write_req) == nil
+    assert Cache.get(cache, read_req) == nil
   end
 end


### PR DESCRIPTION
This adds more checks to the response caching code to not cache
responses that are ok at the I2C level, but not ok from the ATECC. This
addresses a potential (and I think seen) issue where ATECC watchdog
timeout responses were getting cached making it impossible to recover.
