### PR TITLE
Implement authorized key usage via volatile key on ATECC608

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,13 @@ version: 2.1
 latest: &latest
   pattern: "^1.18.*-erlang-27.*$"
 
-tags: &tags
-  [
+tags:
+  &tags [
     1.18.3-erlang-27.3-alpine-3.21.3,
     1.17.3-erlang-27.2-alpine-3.20.3,
     1.16.2-erlang-26.2.4-alpine-3.19.1,
     1.15.7-erlang-26.1.2-alpine-3.18.4,
     1.14.2-erlang-25.2-alpine-3.17.0,
-    1.13.4-erlang-24.3.4-alpine-3.15.3
   ]
 
 jobs:

--- a/lib/atecc508a/configuration/config608.ex
+++ b/lib/atecc508a/configuration/config608.ex
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: 2025 Lars Wikman
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule ATECC508A.Configuration.Config608 do
+  defstruct [
+    :serial_number,
+    :rev_num,
+    :aes_enable,
+    :i2c_enable,
+    :reserved0,
+    :i2c_address,
+    :reserved1,
+    :count_match,
+    :chip_mode,
+    :slot_config,
+    :counter0,
+    :counter1,
+    :use_lock,
+    :volatile_key_permission,
+    :secure_boot,
+    :kdflvloc,
+    :kdflvstr,
+    :reserved2,
+    :user_extra,
+    :user_extra_add,
+    :lock_value,
+    :lock_config,
+    :slot_locked,
+    :chip_options,
+    :x509_format,
+    :key_config
+  ]
+
+  @type t :: %__MODULE__{
+          serial_number: binary(),
+          rev_num: atom() | binary(),
+          aes_enable: non_neg_integer(),
+          i2c_enable: non_neg_integer(),
+          reserved0: byte(),
+          i2c_address: Circuits.I2C.address(),
+          reserved1: byte(),
+          count_match: non_neg_integer(),
+          chip_mode: non_neg_integer(),
+          slot_config: <<_::256>>,
+          counter0: non_neg_integer(),
+          counter1: non_neg_integer(),
+          use_lock: binary(),
+          volatile_key_permission: %{key: non_neg_integer(), enabled?: boolean()},
+          secure_boot: non_neg_integer(),
+          kdflvloc: non_neg_integer(),
+          kdflvstr: non_neg_integer(),
+          reserved2: byte(),
+          user_extra: non_neg_integer(),
+          user_extra_add: non_neg_integer(),
+          lock_value: non_neg_integer(),
+          lock_config: non_neg_integer(),
+          slot_locked: non_neg_integer(),
+          chip_options: non_neg_integer(),
+          x509_format: <<_::32>>,
+          key_config: <<_::256>>
+        }
+
+  def fields do
+    [
+      serial_number_1: 4,
+      rev_num: 4,
+      serial_number_2: 5,
+      aes_enable: 1,
+      i2c_enable: 1,
+      reserved0: 1,
+      i2c_address: 1,
+      reserved1: 1,
+      count_match: 1,
+      chip_mode: 1,
+      slot_config: 32,
+      counter0: 8,
+      counter1: 8,
+      use_lock: 1,
+      volatile_key_permission: 1,
+      secure_boot: 2,
+      kdflvloc: 1,
+      kdflvstr: 2,
+      reserved2: 9,
+      user_extra: 1,
+      user_extra_add: 1,
+      lock_value: 1,
+      lock_config: 1,
+      slot_locked: 2,
+      chip_options: 2,
+      x509_format: 4,
+      key_config: 32
+    ]
+  end
+
+  def bin_fields do
+    [
+      :serial_number,
+      :reserved0,
+      :reserved1,
+      :reserved2,
+      :slot_config,
+      :use_lock,
+      :reserved2,
+      :x509_format,
+      :key_config
+    ]
+  end
+end

--- a/lib/atecc508a/host.ex
+++ b/lib/atecc508a/host.ex
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: 2025 Lars Wikman
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+defmodule ATECC508A.Host do
+  @moduledoc """
+  Implementations of useful operations for the host CPU to perform.
+
+  This is mainly things like constructing a message correctly for hashing.
+  """
+
+  @atecc508a_op_nonce 0x16
+
+  @doc """
+  Generate a random binary of the specified length.
+  """
+  @spec rand(bytes :: non_neg_integer()) :: binary()
+  def rand(bytes) do
+    :crypto.strong_rand_bytes(bytes)
+  end
+
+  @doc """
+  Generate hash using SHA-256.
+  """
+  @spec digest(binary()) :: binary()
+  def digest(msg) do
+    :crypto.hash(:sha256, msg)
+  end
+
+  @doc """
+  Generate a nonce from a random input.
+
+  This matches the nonce implementation of the device.
+
+  It takes an input from the device RNG, the random input the host used to seed the RNG, and the nonce mode.
+
+  It returns a digest.
+  """
+  @spec random_nonce(binary(), binary(), binary()) :: binary()
+  def random_nonce(<<rng::32-bytes>>, <<rand::20-bytes>>, <<nonce_mode::1-bytes>>) do
+    digest(
+      <<rng::32-bytes, rand::20-bytes, @atecc508a_op_nonce::8, nonce_mode::1-bytes, 0x00::8>>
+    )
+  end
+
+  @doc """
+  CheckMac operation on the host.
+
+  This is used for the ClientResp parameter when authorizing a key using
+  CheckMac.
+
+  This implementation does not use the extra bytes of the serial number.
+
+  Returns a map of the constructed message, the digest and the OtherData
+  used when building the message.
+  """
+  @spec checkmac(binary(), binary(), binary()) :: %{
+          msg: binary(),
+          digest: binary(),
+          other: binary()
+        }
+  def checkmac(
+        <<_::32-bytes>> = key,
+        <<_::32-bytes>> = nonce,
+        <<sn0_1::2-bytes, _sn2_3::2-bytes, _sn4_7::4-bytes, sn8::1-bytes>>
+      ) do
+    msg = <<
+      key::32-bytes,
+      nonce::32-bytes,
+      0::size(4 * 8),
+      0::size(8 * 8),
+      0::size(3 * 8),
+      sn8::1-bytes,
+      0::size(4 * 8),
+      sn0_1::2-bytes,
+      0::size(2 * 8)
+    >>
+
+    %{msg: msg, digest: digest(msg), other: <<0::size(13 * 8)>>}
+  end
+
+  @doc """
+  MAC operation on the host.
+
+  This implementation does not use the extra bytes of the serial number.
+
+  Returns a map of the constructed message, the digest and the OtherData
+  used when building the message.
+  """
+  @spec mac(
+          key :: binary(),
+          nonce :: binary(),
+          opcode :: binary(),
+          mode :: binary(),
+          param2 :: binary(),
+          serial_number :: binary()
+        ) :: %{
+          msg: binary(),
+          digest: binary()
+        }
+  def mac(
+        <<_::32-bytes>> = key,
+        <<_::32-bytes>> = nonce,
+        <<_::1-bytes>> = opcode,
+        <<_::1-bytes>> = mode,
+        <<_::2-bytes>> = param2,
+        <<sn0_1::2-bytes, _sn2_3::2-bytes, _sn4_7::4-bytes, sn8::1-bytes>>
+      ) do
+    msg =
+      <<key::32-bytes, nonce::32-bytes, opcode::1-bytes, mode::1-bytes, param2::2-bytes,
+        0::size(8 * 8), 0::size(3 * 8), sn8::1-bytes, 0::size(4 * 8), sn0_1::2-bytes,
+        0::size(2 * 8)>>
+
+    IO.inspect(byte_size(msg))
+
+    %{
+      msg: msg,
+      digest: digest(msg)
+    }
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule ATECC508A.MixProject do
     [
       app: :atecc508a,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/atecc508a/request_test.exs
+++ b/test/atecc508a/request_test.exs
@@ -53,28 +53,28 @@ defmodule ATECC508A.RequestTest do
 
   test "write config zone" do
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<18, 128, 0, 0, @test_data_32::binary>>, 45, 1 ->
+    |> expect(:request, fn _, <<18, 128, 0, 0, @test_data_32::binary>>, 100, 1 ->
       {:ok, <<0>>}
     end)
 
     assert Request.write_zone(@mock_transport, :config, 0, @test_data_32) == :ok
 
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<18, 0, 0, 0, @test_data_4::binary>>, 45, 1 -> {:ok, <<0>>} end)
+    |> expect(:request, fn _, <<18, 0, 0, 0, @test_data_4::binary>>, 100, 1 -> {:ok, <<0>>} end)
 
     assert Request.write_zone(@mock_transport, :config, 0, @test_data_4) == :ok
   end
 
   test "write otp zone" do
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<18, 129, 0, 0, @test_data_32::binary>>, 45, 1 ->
+    |> expect(:request, fn _, <<18, 129, 0, 0, @test_data_32::binary>>, 100, 1 ->
       {:ok, <<0>>}
     end)
 
     assert Request.write_zone(@mock_transport, :otp, 0, @test_data_32) == :ok
 
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<18, 1, 0, 0, @test_data_4::binary>>, 45, 1 -> {:ok, <<0>>} end)
+    |> expect(:request, fn _, <<18, 1, 0, 0, @test_data_4::binary>>, 100, 1 -> {:ok, <<0>>} end)
 
     assert Request.write_zone(@mock_transport, :otp, 0, @test_data_4) == :ok
   end
@@ -98,7 +98,7 @@ defmodule ATECC508A.RequestTest do
 
   test "write data zone" do
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<18, 130, 0, 0, @test_data_32::binary>>, 45, 1 ->
+    |> expect(:request, fn _, <<18, 130, 0, 0, @test_data_32::binary>>, 100, 1 ->
       {:ok, <<0>>}
     end)
 
@@ -107,7 +107,7 @@ defmodule ATECC508A.RequestTest do
 
   test "handles write data zone error" do
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<18, 130, 0, 0, @test_data_32::binary>>, 45, 1 ->
+    |> expect(:request, fn _, <<18, 130, 0, 0, @test_data_32::binary>>, 100, 1 ->
       {:ok, <<1>>}
     end)
 
@@ -117,14 +117,14 @@ defmodule ATECC508A.RequestTest do
 
   test "lock config zone" do
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<0x17, 0, 0xAA, 0x55>>, 35, 1 -> {:ok, <<0>>} end)
+    |> expect(:request, fn _, <<0x17, 0, 0xAA, 0x55>>, 100, 1 -> {:ok, <<0>>} end)
 
     assert Request.lock_zone(@mock_transport, :config, <<0xAA, 0x55>>) == :ok
   end
 
   test "lock data/otp zone" do
     ATECC508A.Transport.Mock
-    |> expect(:request, fn _, <<0x17, 1, 0xAA, 0x55>>, 35, 1 -> {:ok, <<0>>} end)
+    |> expect(:request, fn _, <<0x17, 1, 0xAA, 0x55>>, 100, 1 -> {:ok, <<0>>} end)
 
     assert Request.lock_zone(@mock_transport, :data, <<0xAA, 0x55>>) == :ok
   end


### PR DESCRIPTION
- Add full check_mac and latch-setting transaction: `auth_volatile_key`.
- Add configuration support for more detailed ATECC608 structures.
- Add `Host` module providing some necessary host-side operations.